### PR TITLE
Fix optional body requests

### DIFF
--- a/apis.mustache
+++ b/apis.mustache
@@ -166,7 +166,12 @@ export abstract class {{classname}}Base {
         {{/items}}
         {{/isArray}}
         {{^isArray}}
+        {{#required}}
         let {{paramName}} = {{dataType}}FromJSON(req.body)
+        {{/required}}
+        {{^required}}
+        let {{paramName}} = (Object.entries(req.body).length > 0) ? {{dataType}}FromJSON(req.body) : undefined;
+        {{/required}}
         {{/isArray}}
         {{/isPrimitiveType}}
         {{/bodyParam}}


### PR DESCRIPTION
If an optional request body is not given, express returns an empty object (`{}`) for `req.body`.  This change correctly decodes that to an `undefined` parameter value.